### PR TITLE
feat(filter-presets): add filter presets functionality

### DIFF
--- a/src/controllers/filterPresets.js
+++ b/src/controllers/filterPresets.js
@@ -1,0 +1,82 @@
+const FilterPreset = require('../models/FilterPreset');
+
+// @desc    Get all filter presets for the current user
+// @route   GET /api/filter-presets
+// @access  Private
+exports.getFilterPresets = async (req, res) => {
+  try {
+    const filterPresets = await FilterPreset.find({ user: req.user.id });
+    
+    res.status(200).json({
+      success: true,
+      count: filterPresets.length,
+      data: filterPresets
+    });
+  } catch (error) {
+    console.error('Error fetching filter presets:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Server Error'
+    });
+  }
+};
+
+// @desc    Create a new filter preset
+// @route   POST /api/filter-presets
+// @access  Private
+exports.createFilterPreset = async (req, res) => {
+  try {
+    // Add user to request body
+    req.body.user = req.user.id;
+    
+    const filterPreset = await FilterPreset.create(req.body);
+    
+    res.status(201).json({
+      success: true,
+      data: filterPreset
+    });
+  } catch (error) {
+    console.error('Error creating filter preset:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Server Error'
+    });
+  }
+};
+
+// @desc    Delete a filter preset
+// @route   DELETE /api/filter-presets/:id
+// @access  Private
+exports.deleteFilterPreset = async (req, res) => {
+  try {
+    const filterPreset = await FilterPreset.findById(req.params.id);
+    
+    if (!filterPreset) {
+      return res.status(404).json({
+        success: false,
+        error: 'Filter preset not found'
+      });
+    }
+    
+    // Make sure user owns the filter preset
+    if (filterPreset.user.toString() !== req.user.id) {
+      return res.status(401).json({
+        success: false,
+        error: 'Not authorized to delete this filter preset'
+      });
+    }
+    
+    await filterPreset.remove();
+    
+    res.status(200).json({
+      success: true,
+      data: {}
+    });
+  } catch (error) {
+    console.error('Error deleting filter preset:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Server Error'
+    });
+  }
+};

--- a/src/models/FilterPreset.js
+++ b/src/models/FilterPreset.js
@@ -1,0 +1,25 @@
+const mongoose = require('mongoose');
+
+const FilterPresetSchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: [true, 'Please add a name for this filter preset'],
+    trim: true,
+    maxlength: [50, 'Name cannot be more than 50 characters']
+  },
+  filters: {
+    type: Object,
+    // required: [true, 'Please add filter data']
+  },
+  user: {
+    type: mongoose.Schema.ObjectId,
+    ref: 'User',
+    // required: true
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now
+  }
+});
+
+module.exports = mongoose.model('FilterPreset', FilterPresetSchema);

--- a/src/routes/filterPresets.js
+++ b/src/routes/filterPresets.js
@@ -1,0 +1,21 @@
+const { Router } = require('express');
+const route = Router();
+const {
+  getFilterPresets,
+  createFilterPreset,
+  deleteFilterPreset
+} = require('../controllers/filterPresets');
+
+const { protect } = require('../middleware/auth');
+
+// All routes require authentication
+route.use(protect);
+
+route.route('/api/filter-presets')
+  .get(getFilterPresets)
+  .post(createFilterPreset);
+
+route.route('/api/filter-presets/:id')
+  .delete(deleteFilterPreset);
+
+module.exports = route;

--- a/src/routes/router.js
+++ b/src/routes/router.js
@@ -7,6 +7,7 @@ const schemeRoutes = require('./schemes');
 const distributorRoutes = require('./distributors');
 const productRoutes = require('./products');
 const dashboardRoutes = require('./dashboard');
+const filterPresetRoutes = require('./filterPresets');
 
 // Mount routes with their respective paths
 route.use(authRoutes);
@@ -14,5 +15,6 @@ route.use(schemeRoutes);
 route.use(distributorRoutes);
 route.use(productRoutes);
 route.use(dashboardRoutes);
+route.use(filterPresetRoutes);
 
-module.exports = route;
+module.exports = route; 


### PR DESCRIPTION
Introduce new routes, model, and controller for managing filter presets. This includes endpoints for creating, retrieving, and deleting filter presets, all protected by authentication. The model defines the structure of filter presets, including a name, filters, and user association.